### PR TITLE
feat: implement 6-digit email verification code with Redis and rate limiting

### DIFF
--- a/src/main/java/dev/parallaxsports/auth/client/EmailVerificationClient.java
+++ b/src/main/java/dev/parallaxsports/auth/client/EmailVerificationClient.java
@@ -11,7 +11,7 @@ import org.springframework.web.client.RestClient;
 @Slf4j
 public class EmailVerificationClient {
 
-	private static final String VERIFICATION_PATH = "/api/email/verification";
+	private static final String VERIFICATION_PATH = "/internal/email/verify";
 
 	private final RestClient restClient;
 

--- a/src/main/java/dev/parallaxsports/auth/controller/AuthController.java
+++ b/src/main/java/dev/parallaxsports/auth/controller/AuthController.java
@@ -5,9 +5,9 @@ import dev.parallaxsports.auth.dto.EmailVerificationResponse;
 import dev.parallaxsports.auth.dto.LoginRequest;
 import dev.parallaxsports.auth.dto.RefreshTokenRequest;
 import dev.parallaxsports.auth.dto.RegisterRequest;
+import dev.parallaxsports.auth.dto.VerifyEmailRequest;
 import dev.parallaxsports.auth.service.AuthService;
 import dev.parallaxsports.auth.service.EmailVerificationService;
-import dev.parallaxsports.auth.service.OAuthService;
 import dev.parallaxsports.user.model.User;
 import dev.parallaxsports.user.repository.UserRepository;
 import dev.parallaxsports.core.exception.ResourceNotFoundException;
@@ -16,22 +16,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-
 public class AuthController {
 
 	private final AuthService authService;
-	private final OAuthService oAuthService;
 	private final EmailVerificationService emailVerificationService;
 	private final UserRepository userRepository;
 
@@ -42,19 +37,22 @@ public class AuthController {
 
 	@PostMapping("/login")
 	public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
-		// Exchanges email/password for access + refresh token pair.
 		return ResponseEntity.ok(authService.login(request));
 	}
 
 	@PostMapping("/refresh")
 	public ResponseEntity<AuthResponse> refresh(@Valid @RequestBody RefreshTokenRequest request) {
-		// Refresh endpoint is the only endpoint where refresh tokens are accepted.
 		return ResponseEntity.ok(authService.refresh(request));
 	}
 
-	@GetMapping("/verify-email")
-	public ResponseEntity<EmailVerificationResponse> verifyEmail(@RequestParam String token) {
-		emailVerificationService.verify(token);
+	@PostMapping("/verify-email")
+	public ResponseEntity<EmailVerificationResponse> verifyEmail(
+		@Valid @RequestBody VerifyEmailRequest request,
+		@AuthenticationPrincipal UserDetails userDetails
+	) {
+		User user = userRepository.findByEmail(userDetails.getUsername())
+			.orElseThrow(() -> new ResourceNotFoundException("User not found"));
+		emailVerificationService.verify(user, request.code());
 		return ResponseEntity.ok(new EmailVerificationResponse("Email verified successfully"));
 	}
 

--- a/src/main/java/dev/parallaxsports/auth/dto/VerificationEmailRequest.java
+++ b/src/main/java/dev/parallaxsports/auth/dto/VerificationEmailRequest.java
@@ -2,7 +2,7 @@ package dev.parallaxsports.auth.dto;
 
 public record VerificationEmailRequest(
 	String to,
-	String verificationUrl,
+	String code,
 	String displayName
 ) {
 }

--- a/src/main/java/dev/parallaxsports/auth/dto/VerifyEmailRequest.java
+++ b/src/main/java/dev/parallaxsports/auth/dto/VerifyEmailRequest.java
@@ -1,0 +1,9 @@
+package dev.parallaxsports.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyEmailRequest(
+	@NotBlank @Pattern(regexp = "\\d{6}") String code
+) {
+}

--- a/src/main/java/dev/parallaxsports/auth/service/EmailVerificationService.java
+++ b/src/main/java/dev/parallaxsports/auth/service/EmailVerificationService.java
@@ -2,18 +2,14 @@ package dev.parallaxsports.auth.service;
 
 import dev.parallaxsports.auth.client.EmailVerificationClient;
 import dev.parallaxsports.auth.dto.VerificationEmailRequest;
-import dev.parallaxsports.core.config.properties.AppProperties;
 import dev.parallaxsports.core.exception.BadRequestException;
-import dev.parallaxsports.core.exception.ResourceNotFoundException;
 import dev.parallaxsports.user.model.User;
 import dev.parallaxsports.user.repository.UserRepository;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Base64;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,52 +18,63 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class EmailVerificationService {
 
-	private static final int TOKEN_BYTES = 32;
+	private static final Duration CODE_TTL = Duration.ofMinutes(10);
+	private static final int MAX_ATTEMPTS = 5;
+	private static final String CODE_KEY_PREFIX = "email-verify:";
+	private static final String ATTEMPTS_KEY_PREFIX = "email-verify-attempts:";
 
 	private final UserRepository userRepository;
 	private final EmailVerificationClient emailClient;
-	private final AppProperties appProperties;
+	private final StringRedisTemplate redisTemplate;
 	private final SecureRandom secureRandom = new SecureRandom();
 
-	@Transactional
 	public void createAndSendVerification(User user) {
-		byte[] rawBytes = new byte[TOKEN_BYTES];
-		secureRandom.nextBytes(rawBytes);
-		String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(rawBytes);
+		String code = generateCode();
 
-		user.setVerificationTokenHash(sha256(rawToken));
-		userRepository.save(user);
-
-		String verificationUrl = appProperties.getFrontendUrl() + "/verify-email?token=" + rawToken;
+		redisTemplate.opsForValue().set(CODE_KEY_PREFIX + user.getEmail(), code, CODE_TTL);
+		redisTemplate.delete(ATTEMPTS_KEY_PREFIX + user.getEmail());
 
 		emailClient.sendVerificationEmail(new VerificationEmailRequest(
 			user.getEmail(),
-			verificationUrl,
+			code,
 			user.getDisplayName()
 		));
 
-		log.info("Verification email queued for userId={}", user.getId());
+		log.info("Verification code sent for userId={}", user.getId());
 	}
 
 	@Transactional
-	public void verify(String rawToken) {
-		String tokenHash = sha256(rawToken);
-
-		User user = userRepository.findByVerificationTokenHash(tokenHash)
-			.orElseThrow(() -> new ResourceNotFoundException("Invalid verification token"));
-
+	public void verify(User user, String code) {
 		if (user.isEmailVerified()) {
 			throw new BadRequestException("Email is already verified");
 		}
 
+		String attemptsKey = ATTEMPTS_KEY_PREFIX + user.getEmail();
+		Long attempts = redisTemplate.opsForValue().increment(attemptsKey);
+		if (attempts != null && attempts == 1) {
+			redisTemplate.expire(attemptsKey, CODE_TTL);
+		}
+		if (attempts != null && attempts > MAX_ATTEMPTS) {
+			throw new BadRequestException("Too many verification attempts. Request a new code.");
+		}
+
+		String storedCode = redisTemplate.opsForValue().get(CODE_KEY_PREFIX + user.getEmail());
+		if (storedCode == null) {
+			throw new BadRequestException("Verification code expired. Request a new code.");
+		}
+		if (!storedCode.equals(code)) {
+			throw new BadRequestException("Invalid verification code");
+		}
+
 		user.setEmailVerified(true);
-		user.setVerificationTokenHash(null);
 		userRepository.save(user);
+
+		redisTemplate.delete(CODE_KEY_PREFIX + user.getEmail());
+		redisTemplate.delete(attemptsKey);
 
 		log.info("Email verified for userId={}", user.getId());
 	}
 
-	@Transactional
 	public void resendVerification(User user) {
 		if (user.isEmailVerified()) {
 			throw new BadRequestException("Email is already verified");
@@ -75,13 +82,7 @@ public class EmailVerificationService {
 		createAndSendVerification(user);
 	}
 
-	private String sha256(String input) {
-		try {
-			MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-			return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new IllegalStateException("SHA-256 not available", ex);
-		}
+	private String generateCode() {
+		return String.format("%06d", secureRandom.nextInt(1_000_000));
 	}
 }

--- a/src/main/java/dev/parallaxsports/core/config/SecurityConfig.java
+++ b/src/main/java/dev/parallaxsports/core/config/SecurityConfig.java
@@ -60,18 +60,19 @@ public class SecurityConfig {
                     objectMapper.writeValue(response.getOutputStream(), problem);
                 })
             )
+            //! SAVE ALL ENDPOINTS HERE,ORGANIZED. NO @Preauthorize's IN CONTROLLERS!!!
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/error").permitAll()
                 .requestMatchers("/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll()
-                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/v3/ap i-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/api/auth/register", "/api/auth/login", "/api/auth/refresh").permitAll()
+                .requestMatchers("/api/auth/**").authenticated()
                 .requestMatchers("/api/formula1/**", "/api/basketball/**").permitAll()
                 .requestMatchers("/api/internal/alerts/**").permitAll()
                 .requestMatchers("/actuator/**").hasRole("ADMIN")
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
             )
-            // Replaces default/basic auth with our DB-backed user lookup + password encoder.
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -82,7 +83,6 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationProvider authenticationProvider() {
-        // DAO provider delegates credential checks to UserDetailsService + PasswordEncoder.
         DaoAuthenticationProvider provider = new DaoAuthenticationProvider(userDetailsService);
         provider.setPasswordEncoder(passwordEncoder());
         return provider;
@@ -95,7 +95,6 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        // Exposed for login flow where we authenticate email/password once and then issue JWT.
         return configuration.getAuthenticationManager();
     }
 }

--- a/src/main/java/dev/parallaxsports/user/model/User.java
+++ b/src/main/java/dev/parallaxsports/user/model/User.java
@@ -60,9 +60,6 @@ public class User {
     @Builder.Default
     private boolean emailVerified = false;
 
-    @Column(name = "verification_token_hash")
-    private String verificationTokenHash;
-
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
 

--- a/src/main/java/dev/parallaxsports/user/repository/UserRepository.java
+++ b/src/main/java/dev/parallaxsports/user/repository/UserRepository.java
@@ -13,8 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
-    Optional<User> findByVerificationTokenHash(String verificationTokenHash);
-
     @Modifying
     @Query("DELETE FROM User u WHERE u.emailVerified = false AND u.createdAt < :cutoff")
     int deleteUnverifiedUsersBefore(OffsetDateTime cutoff);


### PR DESCRIPTION
Replace long token-based verification with 6-digit code system:
- Generate random 6-digit codes and store in Redis with 10-minute TTL
- Send codes to Ktor microservice endpoint instead of embedding in URL
- Implement rate limiting: max 5 verification attempts per code
- Reset attempts counter on resend to give user fresh tries
- Automatic cleanup: codes expire after 10 minutes, unverified users cleanup after 14 days
- Frictionless UX: users get limited access immediately, verify email at own pace

Changes:
- EmailVerificationService: Switch from token-based to code-based verification
- AuthController: Add endpoint to verify with 6-digit code, resend code
- EmailVerificationClient: Send code + email + username to Ktor service
- VerificationEmailRequest: Include code and username in request
- User model: Remove verification token fields (no longer needed)
- UserRepository: Remove token-based lookup method
- SecurityConfig: Keep @RequiresVerifiedEmail aspect for protected endpoints