### PR TITLE
Refractor/security closes #37

### DIFF
--- a/src/main/java/dev/parallaxsports/auth/controller/AuthController.java
+++ b/src/main/java/dev/parallaxsports/auth/controller/AuthController.java
@@ -12,7 +12,6 @@ import dev.parallaxsports.auth.service.OAuthService;
 import dev.parallaxsports.auth.service.RefreshTokenService;
 import dev.parallaxsports.core.exception.UnauthorizedException;
 import dev.parallaxsports.user.model.User;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,26 +38,23 @@ public class AuthController {
 	@PostMapping("/register")
 	public ResponseEntity<AuthResponse> register(
 		@Valid @RequestBody RegisterRequest request,
-		HttpServletRequest servletRequest,
 		HttpServletResponse servletResponse
 	) {
-		return ResponseEntity.ok(authService.register(request, servletRequest.getRemoteAddr(), servletResponse));
+		return ResponseEntity.ok(authService.register(request, servletResponse));
 	}
 
 	@PostMapping("/login")
 	public ResponseEntity<AuthResponse> login(
 		@Valid @RequestBody LoginRequest request,
-		HttpServletRequest servletRequest,
 		HttpServletResponse servletResponse
 	) {
-		return ResponseEntity.ok(authService.login(request, servletRequest.getRemoteAddr(), servletResponse));
+		return ResponseEntity.ok(authService.login(request, servletResponse));
 	}
 
 	@PostMapping("/refresh")
 	public ResponseEntity<AuthResponse> refresh(
 		@CookieValue(name = RefreshTokenService.COOKIE_NAME, required = false) String cookieToken,
 		@RequestBody(required = false) RefreshTokenRequest body,
-		HttpServletRequest servletRequest,
 		HttpServletResponse servletResponse
 	) {
 		String token = cookieToken != null ? cookieToken
@@ -66,7 +62,7 @@ public class AuthController {
 		if (token == null || token.isBlank()) {
 			throw new UnauthorizedException("Refresh token required");
 		}
-		return ResponseEntity.ok(authService.refresh(token, servletRequest.getRemoteAddr(), servletResponse));
+		return ResponseEntity.ok(authService.refresh(token, servletResponse));
 	}
 
 	@PostMapping("/logout")

--- a/src/main/java/dev/parallaxsports/auth/dto/AuthResponse.java
+++ b/src/main/java/dev/parallaxsports/auth/dto/AuthResponse.java
@@ -2,8 +2,6 @@ package dev.parallaxsports.auth.dto;
 
 public record AuthResponse(
     Long userId,
-//    String accessToken,
-//    String refreshToken,
     boolean emailVerified
 ) {
 }

--- a/src/main/java/dev/parallaxsports/auth/model/RefreshToken.java
+++ b/src/main/java/dev/parallaxsports/auth/model/RefreshToken.java
@@ -36,9 +36,6 @@ public class RefreshToken {
     @Column(name = "token_hash", nullable = false)
     private String tokenHash;
 
-    @Column(name = "ip_address")
-    private String ipAddress;
-
     @Column(name = "expires_at", nullable = false)
     private OffsetDateTime expiresAt;
 

--- a/src/main/java/dev/parallaxsports/auth/model/TokenType.java
+++ b/src/main/java/dev/parallaxsports/auth/model/TokenType.java
@@ -6,9 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TokenType {
-    ACCESS_TOKEN("access_token", 1800),
-    REFRESH_TOKEN("refresh_token", 604800);
+    ACCESS_TOKEN("access_token"),
+    REFRESH_TOKEN("refresh_token");
 
     private final String cookieName;
-    private final int expiration;
 }

--- a/src/main/java/dev/parallaxsports/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dev/parallaxsports/auth/security/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 			throws ServletException, IOException {
 
-		String requestContext = currentRequestContext(request);
 		String token = extractToken(request);
 
 		if (token == null) {
@@ -47,30 +46,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
 
 				if (jwtTokenProvider.isTokenValid(claims, userDetails, "access")) {
-
-					UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-							userDetails,
-							claims,
-							userDetails.getAuthorities()
-					);
-					authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-					SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+					String jti = claims.getId();
+					if (refreshTokenService.isAccessTokenBlacklisted(jti)) {
+						log.warn("Blacklisted access token rejected jti='{}' uri='{}'", jti, request.getRequestURI());
+					} else {
+						UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+								userDetails,
+								claims,
+								userDetails.getAuthorities()
+						);
+						authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+						SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+					}
 				}
 			}
 		} catch (JwtException | IllegalArgumentException ex) {
-			log.warn("JWT Validation failed: {} {}", ex.getMessage(), requestContext);
+			log.warn("JWT validation failed uri='{}': {}", request.getRequestURI(), ex.getMessage());
 		}
 
 		filterChain.doFilter(request, response);
-	}
-
-	private String currentRequestContext(HttpServletRequest request) {
-		if (request == null) {
-			return "uri=unknown ip=unknown";
-		}
-		String uri = request.getRequestURI() == null ? "unknown" : request.getRequestURI();
-		String ip = request.getRemoteAddr() == null ? "unknown" : request.getRemoteAddr();
-		return "uri='" + uri + "' ip='" + ip + "'";
 	}
 
 	private String extractToken(HttpServletRequest request) {

--- a/src/main/java/dev/parallaxsports/auth/security/OAuth2SuccessHandler.java
+++ b/src/main/java/dev/parallaxsports/auth/security/OAuth2SuccessHandler.java
@@ -10,6 +10,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -19,11 +21,15 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final RefreshTokenService refreshTokenService;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
 
     @Override
     public void onAuthenticationSuccess(@NonNull HttpServletRequest request,
@@ -34,22 +40,27 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = oAuth2User.getAttribute("email");
 
         if (email == null) {
-            throw new RuntimeException("Email not provided by OAuth2 provider");
+            log.warn("OAuth2 login failed: provider did not supply an email address");
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/auth/callback?error=oauth_failed");
+            return;
         }
 
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("User not found after OAuth2 login: " + email));
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            log.warn("OAuth2 login failed: no user found for email='{}' — OAuthService should have created one", email);
+            getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/auth/callback?error=oauth_failed");
+            return;
+        }
 
         String accessToken = jwtTokenProvider.issueAccessToken(user);
         String refreshToken = jwtTokenProvider.issueRefreshToken(user);
         Claims refreshClaims = jwtTokenProvider.parseClaims(refreshToken);
 
-        refreshTokenService.store(user, refreshToken, refreshClaims, request.getRemoteAddr());
+        refreshTokenService.store(user, refreshToken, refreshClaims);
 
         refreshTokenService.addTokenCookie(response, TokenType.REFRESH_TOKEN, refreshToken);
         refreshTokenService.addTokenCookie(response, TokenType.ACCESS_TOKEN, accessToken);
 
-        String targetUrl = "http://localhost:4200/auth/callback";
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+        getRedirectStrategy().sendRedirect(request, response, frontendUrl + "/auth/callback");
     }
 }

--- a/src/main/java/dev/parallaxsports/auth/security/UserDetailsServiceImpl.java
+++ b/src/main/java/dev/parallaxsports/auth/security/UserDetailsServiceImpl.java
@@ -5,7 +5,6 @@ import dev.parallaxsports.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -24,10 +23,6 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		
 		User user = userRepository.findByEmail(username)
 			.orElseThrow(() -> new UsernameNotFoundException("Invalid credentials"));
-
-//		if (user.getPasswordHash() == null || user.getPasswordHash().isBlank()) {
-//			throw new BadCredentialsException("Invalid credentials");
-//		}
 
 		// ROLE_ prefix is required by hasRole("...") checks in SecurityConfig.
 		log.debug("Loaded security principal for '{}'", username);

--- a/src/main/java/dev/parallaxsports/auth/service/AuthService.java
+++ b/src/main/java/dev/parallaxsports/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import dev.parallaxsports.auth.dto.AuthResponse;
 import dev.parallaxsports.auth.dto.LoginRequest;
 import dev.parallaxsports.auth.dto.RegisterRequest;
 import dev.parallaxsports.auth.model.TokenType;
+import dev.parallaxsports.auth.security.UserDetailsServiceImpl;
 import dev.parallaxsports.core.exception.DuplicateResourceException;
 import dev.parallaxsports.core.exception.ResourceNotFoundException;
 import dev.parallaxsports.core.exception.UnauthorizedException;
@@ -34,8 +35,9 @@ public class AuthService {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final EmailVerificationService emailVerificationService;
 	private final RefreshTokenService refreshTokenService;
+	private final UserDetailsServiceImpl userDetailsService;
 
-	public AuthResponse register(RegisterRequest request, String clientIp, HttpServletResponse response) {
+	public AuthResponse register(RegisterRequest request, HttpServletResponse response) {
 		if (userRepository.existsByEmail(request.email())) {
 			throw new DuplicateResourceException("User already exists with email: " + request.email());
 		}
@@ -57,19 +59,10 @@ public class AuthService {
 			log.warn("Verification email could not be sent for user '{}': {}", saved.getEmail(), ex.getMessage());
 		}
 
-		String accessToken = jwtTokenProvider.issueAccessToken(saved);
-		String refreshToken = jwtTokenProvider.issueRefreshToken(saved);
-		Claims refreshClaims = jwtTokenProvider.parseClaims(refreshToken);
-
-		refreshTokenService.store(saved, refreshToken, refreshClaims, clientIp);
-
-		refreshTokenService.addTokenCookie(response, TokenType.REFRESH_TOKEN, refreshToken);
-		refreshTokenService.addTokenCookie(response, TokenType.ACCESS_TOKEN, accessToken);
-
-		return new AuthResponse(saved.getId(), saved.isEmailVerified());
+		return issueAndSetCookies(saved, response);
 	}
 
-	public AuthResponse login(LoginRequest request, String clientIp, HttpServletResponse response) {
+	public AuthResponse login(LoginRequest request, HttpServletResponse response) {
 		try {
 			authenticationManager.authenticate(
 				new UsernamePasswordAuthenticationToken(request.email(), request.password())
@@ -85,19 +78,10 @@ public class AuthService {
 		User saved = userRepository.save(user);
 		log.info("User '{}' logged in", saved.getEmail());
 
-		String accessToken = jwtTokenProvider.issueAccessToken(saved);
-		String refreshToken = jwtTokenProvider.issueRefreshToken(saved);
-		Claims refreshClaims = jwtTokenProvider.parseClaims(refreshToken);
-
-		refreshTokenService.store(saved, refreshToken, refreshClaims, clientIp);
-
-		refreshTokenService.addTokenCookie(response, TokenType.REFRESH_TOKEN, refreshToken);
-		refreshTokenService.addTokenCookie(response, TokenType.ACCESS_TOKEN, accessToken);
-
-		return new AuthResponse(saved.getId(), saved.isEmailVerified());
+		return issueAndSetCookies(saved, response);
 	}
 
-	public AuthResponse refresh(String refreshToken, String clientIp, HttpServletResponse response) {
+	public AuthResponse refresh(String refreshToken, HttpServletResponse response) {
 		Claims claims;
 		try {
 			claims = jwtTokenProvider.parseClaims(refreshToken);
@@ -112,11 +96,7 @@ public class AuthService {
 		User user = userRepository.findByEmail(subject)
 			.orElseThrow(() -> new UnauthorizedException("Invalid refresh token"));
 
-		UserDetails userDetails = org.springframework.security.core.userdetails.User
-			.withUsername(user.getEmail())
-			.password(user.getPasswordHash() == null ? "" : user.getPasswordHash())
-			.authorities("ROLE_" + user.getRole().name())
-			.build();
+		UserDetails userDetails = userDetailsService.loadUserByUsername(subject);
 
 		if (!jwtTokenProvider.isTokenValid(claims, userDetails, "refresh")) {
 			log.warn("Refresh token rejected by validation subject='{}'", subject);
@@ -137,7 +117,7 @@ public class AuthService {
 		String newRefreshToken = jwtTokenProvider.issueRefreshToken(user);
 		Claims newRefreshClaims = jwtTokenProvider.parseClaims(newRefreshToken);
 
-		refreshTokenService.rotateToken(jti, user, newRefreshToken, newRefreshClaims, clientIp);
+		refreshTokenService.rotateToken(jti, user, newRefreshToken, newRefreshClaims);
 
 		refreshTokenService.addTokenCookie(response, TokenType.REFRESH_TOKEN, newRefreshToken);
 		refreshTokenService.addTokenCookie(response, TokenType.ACCESS_TOKEN, newAccessToken);
@@ -158,11 +138,21 @@ public class AuthService {
 				log.debug("Logout with invalid token (ignored): {}", ex.getMessage());
 			}
 		}
-		refreshTokenService.clearRefreshTokenCookie(response);
+		refreshTokenService.clearAuthCookies(response);
 	}
 
 	public User resolveUserByEmail(String email) {
 		return userRepository.findByEmail(email)
 			.orElseThrow(() -> new ResourceNotFoundException("User not found"));
+	}
+
+	private AuthResponse issueAndSetCookies(User user, HttpServletResponse response) {
+		String accessToken = jwtTokenProvider.issueAccessToken(user);
+		String refreshToken = jwtTokenProvider.issueRefreshToken(user);
+		Claims refreshClaims = jwtTokenProvider.parseClaims(refreshToken);
+		refreshTokenService.store(user, refreshToken, refreshClaims);
+		refreshTokenService.addTokenCookie(response, TokenType.REFRESH_TOKEN, refreshToken);
+		refreshTokenService.addTokenCookie(response, TokenType.ACCESS_TOKEN, accessToken);
+		return new AuthResponse(user.getId(), user.isEmailVerified());
 	}
 }

--- a/src/main/java/dev/parallaxsports/auth/service/RefreshTokenCleanupScheduler.java
+++ b/src/main/java/dev/parallaxsports/auth/service/RefreshTokenCleanupScheduler.java
@@ -15,10 +15,7 @@ public class RefreshTokenCleanupScheduler {
 
     private final RefreshTokenRepository refreshTokenRepository;
 
-    /**
-     * Runs daily at 03:00 UTC.
-     * Deletes rows that are either expired or were revoked more than 30 days ago.
-     */
+
     @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void cleanupExpiredAndOldRevoked() {

--- a/src/main/java/dev/parallaxsports/auth/service/RefreshTokenService.java
+++ b/src/main/java/dev/parallaxsports/auth/service/RefreshTokenService.java
@@ -6,7 +6,6 @@ import dev.parallaxsports.auth.repository.RefreshTokenRepository;
 import dev.parallaxsports.core.config.properties.JwtProperties;
 import dev.parallaxsports.user.model.User;
 import io.jsonwebtoken.Claims;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -14,10 +13,12 @@ import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -36,8 +37,11 @@ public class RefreshTokenService {
     private final StringRedisTemplate stringRedisTemplate;
     private final JwtProperties jwtProperties;
 
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
+
     @Transactional
-    public void store(User user, String rawToken, Claims claims, String clientIp) {
+    public void store(User user, String rawToken, Claims claims) {
         String jti = claims.getId();
         OffsetDateTime expiresAt = claims.getExpiration().toInstant().atOffset(ZoneOffset.UTC);
 
@@ -45,7 +49,6 @@ public class RefreshTokenService {
             .tokenId(jti)
             .user(user)
             .tokenHash(sha256hex(rawToken))
-            .ipAddress(clientIp)
             .expiresAt(expiresAt)
             .build();
 
@@ -62,12 +65,12 @@ public class RefreshTokenService {
     }
 
     @Transactional
-    public void rotateToken(String oldJti, User user, String newRawToken, Claims newClaims, String clientIp) {
+    public void rotateToken(String oldJti, User user, String newRawToken, Claims newClaims) {
         refreshTokenRepository.findById(oldJti).ifPresent(rt -> {
             rt.setRevokedAt(OffsetDateTime.now());
             refreshTokenRepository.save(rt);
         });
-        store(user, newRawToken, newClaims, clientIp);
+        store(user, newRawToken, newClaims);
     }
 
     @Transactional
@@ -98,25 +101,31 @@ public class RefreshTokenService {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(BLACKLIST_KEY_PREFIX + jti));
     }
 
-    public void addTokenCookie(HttpServletResponse response, TokenType type, String rawRefreshToken) {
-        ResponseCookie cookie = ResponseCookie.from(type.getCookieName(), rawRefreshToken)
+    public void addTokenCookie(HttpServletResponse response, TokenType type, String rawToken) {
+        long maxAge = (type == TokenType.ACCESS_TOKEN)
+            ? jwtProperties.getAccessTokenExpirationSeconds()
+            : jwtProperties.getRefreshTokenExpirationSeconds();
+        ResponseCookie cookie = ResponseCookie.from(type.getCookieName(), rawToken)
                 .httpOnly(true)
-                .secure(false) // TODO: we change it when de deploy?
+                .secure(cookieSecure)
                 .path("/")
-                .maxAge(type.getExpiration())
+                .maxAge(maxAge)
                 .sameSite("Lax")
                 .build();
-
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    public void clearRefreshTokenCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie(COOKIE_NAME, "");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        cookie.setPath("/");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
+    public void clearAuthCookies(HttpServletResponse response) {
+        for (String name : List.of(TokenType.ACCESS_TOKEN.getCookieName(), TokenType.REFRESH_TOKEN.getCookieName())) {
+            ResponseCookie cookie = ResponseCookie.from(name, "")
+                    .httpOnly(true)
+                    .secure(cookieSecure)
+                    .path("/")
+                    .maxAge(0)
+                    .sameSite("Lax")
+                    .build();
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        }
     }
 
     private static String sha256hex(String input) {

--- a/src/main/java/dev/parallaxsports/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/parallaxsports/core/exception/GlobalExceptionHandler.java
@@ -43,7 +43,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     private static final String typeServiceUnavailable = BASE + "/service-unavailable";
     private static final String typeConfigurationError = BASE + "/configuration-error";
     private static final String typeInternal = BASE + "/internal-error";
-a
 
 
     // -> Triggers: @Valid request-body field errors || Returns: Bad Request (400) + invalid_params

--- a/src/main/java/dev/parallaxsports/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dev/parallaxsports/core/exception/GlobalExceptionHandler.java
@@ -9,8 +9,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.RedisSystemException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
@@ -21,16 +24,12 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-/**
- * Central exception-to-ProblemDetail translator for application and domain errors.
- *
- * This class is responsible for semantic mapping: choosing the most appropriate
- * HTTP status, title, detail, and specific problem type for known exception categories.
- */
+
 @RestControllerAdvice
 @Slf4j
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final String BASE = "/problems";
     private static final String typeNotFound = BASE + "/not-found";
@@ -44,6 +43,48 @@ public class GlobalExceptionHandler {
     private static final String typeServiceUnavailable = BASE + "/service-unavailable";
     private static final String typeConfigurationError = BASE + "/configuration-error";
     private static final String typeInternal = BASE + "/internal-error";
+a
+
+
+    // -> Triggers: @Valid request-body field errors || Returns: Bad Request (400) + invalid_params
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+        MethodArgumentNotValidException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        logHandled(HttpStatus.BAD_REQUEST, ex, request);
+        ProblemDetail problem = buildProblem(
+            typeValidation,
+            HttpStatus.BAD_REQUEST,
+            "Validation Error",
+            "Your request parameters did not validate.",
+            request
+        );
+        List<Map<String, String>> invalidParams = ex.getBindingResult().getFieldErrors().stream()
+            .map(error -> Map.of(
+                "name", error.getField(),
+                "reason", error.getDefaultMessage() == null ? "Invalid value" : error.getDefaultMessage()
+            ))
+            .toList();
+        problem.setProperty("invalid_params", invalidParams);
+        return ResponseEntity.badRequest().body(problem);
+    }
+
+    // -> Triggers: malformed JSON / unreadable request body || Returns: Bad Request (400)
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+        HttpMessageNotReadableException ex,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        logHandled(HttpStatus.BAD_REQUEST, ex, request);
+        return ResponseEntity.badRequest().body(
+            buildProblem(typeMalformedBody, HttpStatus.BAD_REQUEST, "Malformed Request Body", "Malformed request body", request)
+        );
+    }
 
     /*============================================================
       DOMAIN EXCEPTIONS
@@ -51,103 +92,38 @@ public class GlobalExceptionHandler {
     ============================================================*/
 
     // -> Triggers: requested resource does not exist || Returns: Not Found (404)
-    /**
-     * Handles missing domain resources.
-     *
-     * @param ex domain exception with client-safe detail message
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 404
-     */
     @ExceptionHandler(ResourceNotFoundException.class)
     public ProblemDetail handleNotFound(ResourceNotFoundException ex, WebRequest request) {
         logHandled(HttpStatus.NOT_FOUND, ex, request);
-        return buildProblem(
-            typeNotFound,
-            HttpStatus.NOT_FOUND,
-            "Resource Not Found",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeNotFound, HttpStatus.NOT_FOUND, "Resource Not Found", ex.getMessage(), request);
     }
 
     // -> Triggers: business rule validation fails || Returns: Bad Request (400)
-    /**
-     * Handles domain-specific bad request scenarios.
-     *
-     * @param ex domain exception with client-safe detail message
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 400
-     */
     @ExceptionHandler(BadRequestException.class)
     public ProblemDetail handleBadRequest(BadRequestException ex, WebRequest request) {
         logHandled(HttpStatus.BAD_REQUEST, ex, request);
-        return buildProblem(
-            typeBadRequest,
-            HttpStatus.BAD_REQUEST,
-            "Bad Request",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeBadRequest, HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
     }
 
     // -> Triggers: app-level unauthorized flow || Returns: Unauthorized (401)
-    /**
-     * Handles explicit unauthorized exceptions thrown by application logic.
-     *
-     * @param ex unauthorized exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 401
-     */
     @ExceptionHandler(UnauthorizedException.class)
     public ProblemDetail handleUnauthorized(UnauthorizedException ex, WebRequest request) {
         logHandled(HttpStatus.UNAUTHORIZED, ex, request);
-        return buildProblem(
-            typeUnauthorized,
-            HttpStatus.UNAUTHORIZED,
-            "Unauthorized",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeUnauthorized, HttpStatus.UNAUTHORIZED, "Unauthorized", ex.getMessage(), request);
     }
 
     // -> Triggers: duplicate business resource || Returns: Conflict (409)
-    /**
-     * Handles duplicate-resource cases (for example, repeated unique fields).
-     *
-     * @param ex duplicate exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 409
-     */
     @ExceptionHandler(DuplicateResourceException.class)
     public ProblemDetail handleDuplicate(DuplicateResourceException ex, WebRequest request) {
         logHandled(HttpStatus.CONFLICT, ex, request);
-        return buildProblem(
-            typeConflict,
-            HttpStatus.CONFLICT,
-            "Conflict",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeConflict, HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
     }
 
     // -> Triggers: invalid state transition / lifecycle conflict || Returns: Conflict (409)
-    /**
-     * Handles state transition conflicts in lifecycle-driven operations.
-     *
-     * @param ex state conflict exception with client-safe detail message
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 409
-     */
     @ExceptionHandler(StateConflictException.class)
     public ProblemDetail handleStateConflict(StateConflictException ex, WebRequest request) {
         logHandled(HttpStatus.CONFLICT, ex, request);
-        return buildProblem(
-            typeConflict,
-            HttpStatus.CONFLICT,
-            "Conflict",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeConflict, HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
     }
 
     /*============================================================
@@ -156,44 +132,19 @@ public class GlobalExceptionHandler {
     ============================================================*/
 
     // -> Triggers: DB integrity violation || Returns: Conflict (409) or Bad Request (400)
-    /**
-     * Translates low-level data integrity violations to stable API responses.
-     *
-     * @param ex data integrity exception from persistence layer
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 409 or 400
-     */
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ProblemDetail handleDataIntegrityViolation(DataIntegrityViolationException ex, WebRequest request) {
         String reason = extractMostSpecificMessage(ex).toLowerCase();
         if (reason.contains("unique") || reason.contains("duplicate")) {
             logHandled(HttpStatus.CONFLICT, ex, request);
-            return buildProblem(
-                typeConflict,
-                HttpStatus.CONFLICT,
-                "Conflict",
-                "Resource conflicts with an existing record",
-                request
-            );
+            return buildProblem(typeConflict, HttpStatus.CONFLICT, "Conflict", "Resource conflicts with an existing record", request);
         }
         if (reason.contains("check constraint") || reason.contains("foreign key")) {
             logHandled(HttpStatus.BAD_REQUEST, ex, request);
-            return buildProblem(
-                typeBadRequest,
-                HttpStatus.BAD_REQUEST,
-                "Bad Request",
-                "Request violates data constraints",
-                request
-            );
+            return buildProblem(typeBadRequest, HttpStatus.BAD_REQUEST, "Bad Request", "Request violates data constraints", request);
         }
         logHandled(HttpStatus.BAD_REQUEST, ex, request);
-        return buildProblem(
-            typeBadRequest,
-            HttpStatus.BAD_REQUEST,
-            "Bad Request",
-            "Invalid data",
-            request
-        );
+        return buildProblem(typeBadRequest, HttpStatus.BAD_REQUEST, "Bad Request", "Invalid data", request);
     }
 
     /*============================================================
@@ -201,136 +152,44 @@ public class GlobalExceptionHandler {
       Authentication and authorization boundaries
     ============================================================*/
 
-    // -> Triggers: authenticated user lacks permission || Returns: Forbidden (403)
-    /**
-     * Handles authorization denials for protected resources.
-     *
-     * @param ex access denied exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 403
-     */
+    // -> Triggers: authenticated user lacks permission (e.g. @RequiresVerifiedEmail AOP) || Returns: Forbidden (403)
     @ExceptionHandler(AccessDeniedException.class)
     public ProblemDetail handleAccessDenied(AccessDeniedException ex, WebRequest request) {
         logHandled(HttpStatus.FORBIDDEN, ex, request);
-        return buildProblem(
-            typeForbidden,
-            HttpStatus.FORBIDDEN,
-            "Forbidden",
-            "Access denied",
-            request
-        );
+        return buildProblem(typeForbidden, HttpStatus.FORBIDDEN, "Forbidden", "Access denied", request);
     }
 
-    // -> Triggers: Spring Security auth failure (includes BadCredentialsException) || Returns: Unauthorized (401)
-    /**
-     * Handles Spring Security authentication failures.
-     *
-     * @param ex authentication exception (includes bad credentials and similar auth errors)
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 401
-     */
+    // -> Triggers: Spring Security auth failure thrown from application code || Returns: Unauthorized (401)
     @ExceptionHandler(AuthenticationException.class)
     public ProblemDetail handleAuthenticationFailure(AuthenticationException ex, WebRequest request) {
         logHandled(HttpStatus.UNAUTHORIZED, ex, request);
-        return buildProblem(
-            typeUnauthorized,
-            HttpStatus.UNAUTHORIZED,
-            "Unauthorized",
-            "Invalid credentials",
-            request
-        );
+        return buildProblem(typeUnauthorized, HttpStatus.UNAUTHORIZED, "Unauthorized", "Invalid credentials", request);
     }
 
     /*============================================================
       VALIDATION EXCEPTIONS
-      Bean validation and request body parsing failures
+      Bean validation constraint failures
     ============================================================*/
 
-    // -> Triggers: method parameter constraint violations || Returns: Bad Request (400)
-    /**
-     * Handles method-level constraint validation errors.
-     *
-     * @param ex constraint violation exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 400 and violation map
-     */
+    // -> Triggers: method parameter constraint violations || Returns: Bad Request (400) + invalid_params
     @ExceptionHandler(ConstraintViolationException.class)
     public ProblemDetail handleConstraintViolation(ConstraintViolationException ex, WebRequest request) {
         logHandled(HttpStatus.BAD_REQUEST, ex, request);
-        ProblemDetail problemDetail = buildProblem(
+        ProblemDetail problem = buildProblem(
             typeValidation,
             HttpStatus.BAD_REQUEST,
             "Validation Error",
             "Your request parameters did not validate.",
             request
         );
-        List<Map<String, String>> invalidParams = ex.getConstraintViolations()
-            .stream()
-            .map(violation ->
-                Map.of(
-                    "name",
-                    violation.getPropertyPath().toString(),
-                    "reason",
-                    violation.getMessage() == null ? "Invalid value" : violation.getMessage()
-                )
-            )
+        List<Map<String, String>> invalidParams = ex.getConstraintViolations().stream()
+            .map(violation -> Map.of(
+                "name", violation.getPropertyPath().toString(),
+                "reason", violation.getMessage() == null ? "Invalid value" : violation.getMessage()
+            ))
             .toList();
-        problemDetail.setProperty("invalid_params", invalidParams);
-        return problemDetail;
-    }
-
-    // -> Triggers: @Valid request-body field errors || Returns: Bad Request (400)
-    /**
-     * Handles bean validation failures for request body DTOs.
-     *
-     * @param ex method argument validation exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 400 and field error map
-     */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ProblemDetail handleMethodArgumentNotValid(MethodArgumentNotValidException ex, WebRequest request) {
-        logHandled(HttpStatus.BAD_REQUEST, ex, request);
-        ProblemDetail problemDetail = buildProblem(
-            typeValidation,
-            HttpStatus.BAD_REQUEST,
-            "Validation Error",
-            "Your request parameters did not validate.",
-            request
-        );
-        List<Map<String, String>> invalidParams = ex.getBindingResult()
-            .getFieldErrors()
-            .stream()
-            .map(error ->
-                Map.of(
-                    "name",
-                    error.getField(),
-                    "reason",
-                    error.getDefaultMessage() == null ? "Invalid value" : error.getDefaultMessage()
-                )
-            )
-            .collect(Collectors.toList());
-        problemDetail.setProperty("invalid_params", invalidParams);
-        return problemDetail;
-    }
-
-    // -> Triggers: malformed JSON / unreadable request body || Returns: Bad Request (400)
-    /**
-     * Handles JSON parse and request-body deserialization failures.
-     *
-     * @param ex unreadable message exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 400
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ProblemDetail handleHttpMessageNotReadable(HttpMessageNotReadableException ex, WebRequest request) {
-        logHandled(HttpStatus.BAD_REQUEST, ex, request);
-        return buildProblem(
-            typeMalformedBody,
-            HttpStatus.BAD_REQUEST,
-            "Malformed Request Body",
-            "Malformed request body",
-            request
-        );
+        problem.setProperty("invalid_params", invalidParams);
+        return problem;
     }
 
     /*============================================================
@@ -339,57 +198,22 @@ public class GlobalExceptionHandler {
     ============================================================*/
 
     // -> Triggers: explicit status raised by lower application layers || Returns: propagated status
-    /**
-     * Preserves explicit HTTP status semantics from ResponseStatusException.
-     *
-     * @param ex status exception carrying status code and optional reason
-     * @param request current web request
-     * @return RFC ProblemDetail payload with propagated status and detail
-     */
     @ExceptionHandler(ResponseStatusException.class)
     public ProblemDetail handleResponseStatus(ResponseStatusException ex, WebRequest request) {
         HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
         logHandled(status, ex, request);
         String detail = ex.getReason() == null ? status.getReasonPhrase() : ex.getReason();
-
-        // Keep explicit semantics minimal here; response advice upgrades about:blank to a concrete type URI.
-        return buildProblem(
-            "about:blank",
-            status,
-            status.getReasonPhrase(),
-            detail,
-            request
-        );
+        return buildProblem("about:blank", status, status.getReasonPhrase(), detail, request);
     }
 
     // -> Triggers: upstream dependency returned an error response || Returns: Bad Gateway (502)
-    /**
-     * Handles upstream service failures returned by external dependencies.
-     *
-     * @param ex upstream exception with client-safe detail message
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 502
-     */
     @ExceptionHandler(UpstreamServiceException.class)
     public ProblemDetail handleUpstreamService(UpstreamServiceException ex, WebRequest request) {
         logHandled(HttpStatus.BAD_GATEWAY, ex, request);
-        return buildProblem(
-            typeBadGateway,
-            HttpStatus.BAD_GATEWAY,
-            "Bad Gateway",
-            ex.getMessage(),
-            request
-        );
+        return buildProblem(typeBadGateway, HttpStatus.BAD_GATEWAY, "Bad Gateway", ex.getMessage(), request);
     }
 
     // -> Triggers: Redis or dependent service temporarily unavailable || Returns: Service Unavailable (503)
-    /**
-     * Handles temporary infrastructure unavailability from runtime dependencies.
-     *
-     * @param ex runtime exception from service infrastructure dependencies
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 503
-     */
     @ExceptionHandler({
         ServiceUnavailableException.class,
         RedisConnectionFailureException.class,
@@ -407,63 +231,23 @@ public class GlobalExceptionHandler {
     }
 
     // -> Triggers: outbound HTTP client call failed || Returns: Bad Gateway (502)
-    /**
-     * Handles transport-level outbound HTTP failures to external services.
-     *
-     * @param ex REST client exception from outbound integration path
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 502
-     */
     @ExceptionHandler(RestClientException.class)
     public ProblemDetail handleRestClientException(RestClientException ex, WebRequest request) {
         logHandled(HttpStatus.BAD_GATEWAY, ex, request);
-        return buildProblem(
-            typeBadGateway,
-            HttpStatus.BAD_GATEWAY,
-            "Bad Gateway",
-            "Upstream service request failed",
-            request
-        );
+        return buildProblem(typeBadGateway, HttpStatus.BAD_GATEWAY, "Bad Gateway", "Upstream service request failed", request);
     }
 
-    // -> Triggers: missing/invalid runtime configuration || Returns: Internal Server Error (500)
-    /**
-     * Handles runtime system configuration failures that block normal operation.
-     *
-    * Example: when the basketball API key is not configured
-    * (`app.external-api.balldontlie-api-key`),
-     * basketball sync endpoints cannot execute and should return an explicit
-     * service-unavailable/configuration problem shape instead of a generic 500.
-     *
-     * @param ex configuration exception with operator-facing detail message
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 503 for missing required runtime config,
-     *         otherwise status 500
-     */
+    // -> Triggers: missing/invalid runtime configuration || Returns: Internal Server Error (500) or Service Unavailable (503)
     @ExceptionHandler(SystemConfigurationException.class)
     public ProblemDetail handleSystemConfiguration(SystemConfigurationException ex, WebRequest request) {
         String message = ex.getMessage() == null ? "System configuration error" : ex.getMessage();
         boolean missingRequiredConfig = message.toLowerCase().contains("must be configured");
-
         if (missingRequiredConfig) {
             logHandled(HttpStatus.SERVICE_UNAVAILABLE, ex, request);
-            return buildProblem(
-                typeConfigurationError,
-                HttpStatus.SERVICE_UNAVAILABLE,
-                "Service Unavailable",
-                message,
-                request
-            );
+            return buildProblem(typeConfigurationError, HttpStatus.SERVICE_UNAVAILABLE, "Service Unavailable", message, request);
         }
-
         logHandled(HttpStatus.INTERNAL_SERVER_ERROR, ex, request);
-        return buildProblem(
-            typeInternal,
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            message,
-            request
-        );
+        return buildProblem(typeInternal, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", message, request);
     }
 
     /*============================================================
@@ -472,23 +256,10 @@ public class GlobalExceptionHandler {
     ============================================================*/
 
     // -> Triggers: unhandled exception fallback || Returns: Internal Server Error (500)
-    /**
-     * Handles uncaught exceptions not matched by more specific handlers.
-     *
-     * @param ex unexpected exception
-     * @param request current web request
-     * @return RFC ProblemDetail payload with status 500
-     */
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleUnexpected(Exception ex, WebRequest request) {
         logHandled(HttpStatus.INTERNAL_SERVER_ERROR, ex, request);
-        return buildProblem(
-            typeInternal,
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "An unexpected error occurred",
-            request
-        );
+        return buildProblem(typeInternal, HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "An unexpected error occurred", request);
     }
 
     /*============================================================
@@ -496,49 +267,19 @@ public class GlobalExceptionHandler {
       Logging, payload shaping, and DB message extraction
     ============================================================*/
 
-    /**
-     * Writes structured exception logs for observability pipelines.
-     *
-     * @param status HTTP status that will be returned
-     * @param ex exception to log
-     * @param request current web request
-     */
     private void logHandled(HttpStatus status, Throwable ex, WebRequest request) {
         String path = requestPath(request);
         String exceptionType = ex == null ? "UnknownException" : ex.getClass().getSimpleName();
         String message = ex == null || ex.getMessage() == null ? "" : ex.getMessage();
-
         if (status.is5xxServerError()) {
-            log.error(
-                "api_exception status={} path='{}' exception='{}' message='{}'",
-                status.value(),
-                path,
-                exceptionType,
-                message,
-                ex
-            );
+            log.error("api_exception status={} path='{}' exception='{}' message='{}'",
+                status.value(), path, exceptionType, message, ex);
             return;
         }
-
-        log.warn(
-            "api_exception status={} path='{}' exception='{}' message='{}'",
-            status.value(),
-            path,
-            exceptionType,
-            message
-        );
+        log.warn("api_exception status={} path='{}' exception='{}' message='{}'",
+            status.value(), path, exceptionType, message);
     }
 
-    /**
-     * Builds a ProblemDetail payload with semantic type, status, title, detail, and instance path.
-     *
-     * @param type problem type URI
-     * @param status HTTP status for the response
-     * @param title short problem title
-     * @param detail client-safe detail message
-     * @param request current web request
-     * @return initialized ProblemDetail object
-     */
     private ProblemDetail buildProblem(String type, HttpStatus status, String title, String detail, WebRequest request) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
         problemDetail.setType(URI.create(type));
@@ -551,24 +292,12 @@ public class GlobalExceptionHandler {
         return problemDetail;
     }
 
-    /**
-     * Extracts request path for logs and ProblemDetail instance field.
-     *
-     * @param request current web request
-     * @return request URI or "unknown" when not running in servlet context
-     */
     private String requestPath(WebRequest request) {
         return request instanceof ServletWebRequest servletWebRequest
             ? servletWebRequest.getRequest().getRequestURI()
             : "unknown";
     }
 
-    /**
-     * Extracts the deepest available database error message.
-     *
-     * @param ex data integrity violation exception
-     * @return most specific cause message, or fallback exception message, or empty string
-     */
     private String extractMostSpecificMessage(DataIntegrityViolationException ex) {
         Throwable mostSpecificCause = ex.getMostSpecificCause();
         if (mostSpecificCause != null && mostSpecificCause.getMessage() != null) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,9 +14,6 @@ spring:
           max-wait: 2000ms
   application:
     name: parallax-sports-api
-  mvc:
-    problemdetails:
-      enabled: true
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/postgres}
     username: ${DB_USER:postgres}
@@ -51,6 +48,8 @@ spring:
 
 app:
   frontend-url: ${FRONTEND_URL:http://localhost:4200}
+  cookie:
+    secure: ${COOKIE_SECURE:false}
   bot:
     api-key: ${BOT_API_KEY:dev-change-me-bot-api-key}
   jwt:


### PR DESCRIPTION
- UserDetailsServiceImpl: remove commented-out BadCredentialsException block
- AuthResponse: remove commented-out token fields (tokens go in cookies, not body)
- RefreshTokenCleanupScheduler: remove stale Javadoc