### PR TITLE
small refractors + cleanup of secrets

### DIFF
--- a/src/main/java/dev/parallaxsports/external/sync/ExternalApiDailyScheduler.java
+++ b/src/main/java/dev/parallaxsports/external/sync/ExternalApiDailyScheduler.java
@@ -4,12 +4,14 @@ import dev.parallaxsports.core.config.properties.ExternalSyncProperties;
 import dev.parallaxsports.sport.event.service.EventFeedService;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -97,8 +99,15 @@ public class ExternalApiDailyScheduler {
 
     private void invalidateEventFeedCache() {
         try {
-            Set<String> keys = redisTemplate.keys(EventFeedService.CACHE_PREFIX + "*");
-            if (keys != null && !keys.isEmpty()) {
+            ScanOptions options = ScanOptions.scanOptions()
+                .match(EventFeedService.CACHE_PREFIX + "*")
+                .count(100)
+                .build();
+            List<String> keys = new ArrayList<>();
+            try (Cursor<String> cursor = redisTemplate.scan(options)) {
+                cursor.forEachRemaining(keys::add);
+            }
+            if (!keys.isEmpty()) {
                 redisTemplate.delete(keys);
                 log.info("Invalidated {} event feed cache entries", keys.size());
             }

--- a/src/main/java/dev/parallaxsports/sport/event/service/EventFeedService.java
+++ b/src/main/java/dev/parallaxsports/sport/event/service/EventFeedService.java
@@ -57,9 +57,15 @@ public class EventFeedService {
         }
 
         Pageable limit = PageRequest.ofSize(size + 1);
-        List<Event> events = afterId == null
-            ? eventRepository.findAllByTimeBetween(from, to, limit)
-            : eventRepository.findAllByTimeBetweenAfterCursor(from, to, afterId, limit);
+        List<Event> events;
+        if (afterId == null) {
+            events = eventRepository.findAllByTimeBetween(from, to, limit);
+        } else {
+            if (!eventRepository.existsById(afterId)) {
+                throw new IllegalArgumentException("Invalid cursor: event id " + afterId + " not found");
+            }
+            events = eventRepository.findAllByTimeBetweenAfterCursor(from, to, afterId, limit);
+        }
 
         boolean hasMore = events.size() > size;
         if (hasMore) {

--- a/src/main/java/dev/parallaxsports/user/repository/UserRepository.java
+++ b/src/main/java/dev/parallaxsports/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     @Query("""
-        SELECT u FROM User u
+        SELECT DISTINCT u FROM User u
         LEFT JOIN FETCH u.settings
         LEFT JOIN FETCH u.identities
         LEFT JOIN FETCH u.sportSettings

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,6 @@ spring:
       - optional:classpath:api-secrets.yml
   data:
     redis:
-      host: localhost
       port: 6379
       password:
       timeout: 2000
@@ -17,10 +16,6 @@ spring:
           max-wait: 2000ms
   application:
     name: parallax-sports-api
-  datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password: 12345
   jpa:
     open-in-view: false
   security:
@@ -28,8 +23,6 @@ spring:
       client:
         registration:
           discord:
-            client-id: dev-change-me-oauth-discord-id
-            client-secret: dev-change-me-oauth-discord-secret
             scope:
               - identify
               - email
@@ -37,8 +30,6 @@ spring:
             redirect-uri: "http://localhost:8080/login/oauth2/code/discord"
             client-name: Discord
           google:
-            client-id: dev-change-me-oauth-google-id
-            client-secret: dev-change-me-oauth-google-secret
             scope:
               - email
               - profile
@@ -53,16 +44,12 @@ app:
   frontend-url: http://localhost:4200
   cookie:
     secure: false
-  bot:
-    api-key: dev-change-me-bot-api-key
   jwt:
-    secret: dev-change-me-jwt-secret-32chars
     access-token-expiration-seconds: 900
     refresh-token-expiration-seconds: 604800
   external-api:
     openf1-base-url: https://api.openf1.org/v1
     balldontlie-base-url: https://api.balldontlie.io
-    balldontlie-api-key:
   external-sync:
     enabled: true
     zone-id: UTC
@@ -88,9 +75,6 @@ springdoc:
     path: /swagger-ui.html
     operations-sorter: method
     tags-sorter: alpha
-
-observability:
-  loki-url: http://localhost:3100
 
 management:
   endpoints:


### PR DESCRIPTION
An unknown afterId caused the cursor subquery to return null and silently yield an empty page; now validated with existsById before querying. 

Added SELECT DISTINCT to the full-profile user query to prevent row duplication from multiple collection fetch-joins.